### PR TITLE
No more torch import

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,9 +2,9 @@ Add description here
 
 
 * [ ] All new vintage model is described in a paper_review.md and is used in an experiment script
-* [ ] All the new modules are tested, and these tests contains a gpu optional test
-* [ ] All the new modules are compatible with the `.device` instruction
+* [ ] All the new modules are tested, and these tests contain a gpu optional test
+* [ ] All the new modules are compatible with the `.to(device)` instruction
 * [ ] All modules are documented with a docstring
-* [ ] `import torch` is used only if it is the only option
+* [ ] `import torch` is used only if it is the only option (acceptable in tests or experiments)
 * [ ] The loss computation are not included in the model class itself
 * [ ] If the model is used to generate images, the generation function is not in the model class

--- a/vintage_models/components/convolution.py
+++ b/vintage_models/components/convolution.py
@@ -1,5 +1,4 @@
-import torch
-from torch import Tensor
+from torch import Tensor, cat
 from torch.nn import Conv2d, ModuleList, Module
 from torch.nn.common_types import _size_2_t
 
@@ -60,4 +59,4 @@ class FilteredConv2d(Module):
         ):
             conv_result_list.append(conv2d(x[:, in_channels]))
 
-        return torch.cat(conv_result_list, dim=-3)
+        return cat(conv_result_list, dim=-3)

--- a/vintage_models/components/rbf.py
+++ b/vintage_models/components/rbf.py
@@ -1,5 +1,4 @@
-import torch
-from torch import stack
+from torch import stack, sum as torch_sum
 from torch.nn import Linear, MSELoss
 
 from torch.nn.functional import mse_loss
@@ -36,4 +35,4 @@ class EuclideanDistanceRBF(Linear):
         weights = stack([self.weight.transpose(0, 1)] * x.shape[0], dim=0)
         x = stack([x] * self.out_features, dim=-1)
         loss = mse_loss(x, weights, reduction="none")
-        return torch.sum(loss, dim=1)
+        return torch_sum(loss, dim=1)


### PR DESCRIPTION
We want to have consistent import definitions. We want to avoid any direct `import torch` thus we remove the last ones


* [ ] All new vintage model is described in a paper_review.md and is used in an experiment script
* [ ] All the new modules are tested, and these tests contains a gpu optional test
* [ ] All the new modules are compatible with the `.device` instruction
* [ ] All modules are documented with a docstring
* [x] `import torch` is used only if it is the only option
* [ ] The loss computation are not included in the model class itself
* [ ] If the model is used to generate images, the generation function is not in the model class


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced clarity and specificity of the pull request template checklist items.
	- Corrected grammatical errors and updated compatibility instructions for improved guidance.
  
- **Chores**
	- Updated import statements for improved readability in convolution and RBF components without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->