### PR TITLE
Make the layers in the vit encoder all different

### DIFF
--- a/vintage_models/vision_transformers/vit/vit.py
+++ b/vintage_models/vision_transformers/vit/vit.py
@@ -71,14 +71,14 @@ class ViTEncoder(Module):
         self.head_count = head_count
 
         self.model = Sequential(
-            {
-                f"layer_{layer_idx}": ViTEncoderLayer(
+            *[
+                ViTEncoderLayer(
                     head_count=head_count,
                     embedding_len=embedding_len,
                     mlp_hidden_size=mlp_hidden_size,
                 )
-                for layer_idx in range(layer_count)
-            }
+                for _ in range(layer_count)
+            ]
         )
 
     def forward(self, x: Tensor) -> Tensor:

--- a/vintage_models/vision_transformers/vit/vit.py
+++ b/vintage_models/vision_transformers/vit/vit.py
@@ -8,6 +8,7 @@ from vintage_models.components.positional_encoding import LearnablePositionalEnc
 from vintage_models.components.residual import ResidualWithSelfAttention
 from vintage_models.utility.transform import PaddingMode
 
+
 class ViTEncoderLayer(Module):
     """Layer of the ViT encoder
 
@@ -18,6 +19,7 @@ class ViTEncoderLayer(Module):
         self_attention_residual: The residual module for the self attention (attention plus normalization).
         mlp_residual: The residual module for the MLP (mlp plus normalization).
     """
+
     def __init__(
         self,
         head_count: int,

--- a/vintage_models/vision_transformers/vit/vit.py
+++ b/vintage_models/vision_transformers/vit/vit.py
@@ -18,16 +18,17 @@ class ViTEncoderLayer(Module):
         self_attention_residual: The residual module for the self attention (attention plus normalization).
         mlp_residual: The residual module for the MLP (mlp plus normalization).
     """
-
     def __init__(
         self,
         head_count: int,
         embedding_len: int,
         mlp_hidden_size: int,
     ) -> None:
+        super().__init__()
         self.embedding_len = embedding_len
         self.mlp_hidden_size = mlp_hidden_size
         self.head_count = head_count
+
         self.self_attention_residual = ResidualWithSelfAttention(
             [
                 LayerNorm(embedding_len),

--- a/vintage_models/vision_transformers/vit/vit.py
+++ b/vintage_models/vision_transformers/vit/vit.py
@@ -55,6 +55,7 @@ class ViTEncoder(Module):
 
     Attributes:
         layer_count: The number of layers to apply.
+        head_count: the number of head in multihead attention modules
         model: The stack of ViT layers.
     """
 
@@ -67,6 +68,7 @@ class ViTEncoder(Module):
     ) -> None:
         super().__init__()
         self.layer_count = layer_count
+        self.head_count = head_count
 
         self.model = Sequential(
             {


### PR DESCRIPTION
I was probably not so focused when created the ViT Encoder class. here is the fix.


* [ ] All new vintage model is described in a paper_review.md and is used in an experiment script
* [ ] All the new modules are tested, and these tests contain a gpu optional test
* [ ] All the new modules are compatible with the `.to(device)` instruction
* [x] All modules are documented with a docstring
* [x] `import torch` is used only if it is the only option (acceptable in tests or experiments)
* [ ] The loss computation are not included in the model class itself
* [ ] If the model is used to generate images, the generation function is not in the model class


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new class for handling individual layers in the visual transformer encoder, improving processing efficiency.
  - Added a new encoder class to manage multiple layers, enhancing the overall structure and functionality.

- **Documentation**
  - Added docstrings for the new encoder classes to provide clearer guidance on their attributes and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->